### PR TITLE
Action: Add nearly_reached into the list

### DIFF
--- a/app/src/main/java/io/aayush/relabs/network/data/alert/Action.kt
+++ b/app/src/main/java/io/aayush/relabs/network/data/alert/Action.kt
@@ -43,5 +43,8 @@ enum class Action {
     REACHED,
 
     @Json(name = "question_solution")
-    SOLUTION
+    SOLUTION,
+
+    @Json(name = "nearly_reached")
+    NEARLY_REACHED
 }


### PR DESCRIPTION
Required by user achievement notifications if a certain level is reached.

Example:
![image](https://github.com/theimpulson/ReLabs/assets/5193379/5f0b21ce-511a-4d48-a3d1-0af0ea4b2518)